### PR TITLE
Feature - Adds audit legend to the inactive validators table

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -10,6 +10,7 @@
     "node": "^20.11.1"
   },
   "scripts": {
+    "clean": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",

--- a/api/src/ol/models/validator.model.ts
+++ b/api/src/ol/models/validator.model.ts
@@ -1,6 +1,54 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import BN from 'bn.js';
 
+export interface IVoucherInput {
+  address: string;
+  epoch: number;
+}
+
+@ObjectType('Voucher')
+export class Voucher {
+  public constructor(input: IVoucherInput) {
+    this.address = input.address;
+    this.epoch = input.epoch;
+  }
+
+  @Field(() => String)
+  public address: string;
+
+  @Field(() => Number)
+  public epoch: number;
+}
+
+interface IVouchesInput {
+  valid: number;
+  total: number;
+  compliant: boolean;
+  vouchers: Voucher[];
+}
+
+@ObjectType('Vouches')
+export class Vouches {
+  public constructor(input: IVouchesInput) {
+    this.valid = input.valid;
+    this.total = input.total;
+    this.compliant = input.compliant;
+    this.vouchers = input.vouchers;
+  }
+
+  @Field(() => Number)
+  public valid: number;
+
+  @Field(() => Number)
+  public total: number;
+
+  @Field(() => Boolean)
+  public compliant: boolean;
+
+  @Field(() => [Voucher])
+  public vouchers: Voucher[];
+}
+
 @ObjectType('ValidatorCurrentBid')
 export class GqlValidatorCurrentBid {
   public constructor(input: GqlValidatorCurrentBidInput) {
@@ -52,7 +100,7 @@ interface ValidatorInput {
   unlocked?: number;
   votingPower: BN;
   grade?: GqlValidatorGrade | null;
-  vouches: GqlVouch[];
+  vouches: Vouches;
   currentBid: GqlValidatorCurrentBid;
   city?: string | null;
   country?: string | null;
@@ -97,8 +145,8 @@ export class Validator {
   @Field(() => GqlValidatorGrade, { nullable: true })
   public grade?: GqlValidatorGrade | null;
 
-  @Field(() => [GqlVouch], { nullable: true })
-  public vouches?: GqlVouch[];
+  @Field(() => Vouches, { nullable: true })
+  public vouches?: Vouches;
 
   @Field(() => GqlValidatorCurrentBid, { nullable: true })
   public currentBid?: GqlValidatorCurrentBid;
@@ -111,23 +159,4 @@ export class Validator {
 
   @Field(() => [String], { nullable: true })
   public auditQualification?: [string] | null;
-}
-
-interface GqlVouchInput {
-  epoch: number;
-  address: string;
-}
-
-@ObjectType('Vouch')
-export class GqlVouch {
-  public constructor(input: GqlVouchInput) {
-    this.epoch = input.epoch;
-    this.address = input.address;
-  }
-
-  @Field(() => Number)
-  public epoch: number;
-
-  @Field(() => String)
-  public address: string;
 }

--- a/api/src/schema.gql
+++ b/api/src/schema.gql
@@ -41,6 +41,18 @@ type UserTransactionCollection {
   items: [GqlUserTransactionDeprecated!]!
 }
 
+type Voucher {
+  address: String!
+  epoch: Float!
+}
+
+type Vouches {
+  valid: Float!
+  total: Float!
+  compliant: Boolean!
+  vouchers: [Voucher!]!
+}
+
 type ValidatorCurrentBid {
   currentBid: Float!
   expirationEpoch: Float!
@@ -60,16 +72,11 @@ type Validator {
   country: String
   votingPower: BigInt!
   grade: ValidatorGrade
-  vouches: [Vouch!]
+  vouches: Vouches
   currentBid: ValidatorCurrentBid
   balance: Float
   unlocked: Float
   auditQualification: [String!]
-}
-
-type Vouch {
-  epoch: Float!
-  address: String!
 }
 
 type Account {

--- a/web-app/src/config.ts
+++ b/web-app/src/config.ts
@@ -22,7 +22,7 @@ const configMap = new Map<string, Config>([
     },
   ],
   [
-    'localhost',
+    '127.0.0.1',
     {
       apiHost: API_HOST,
       dataApiHost: VITE_DATA_API_HOST,

--- a/web-app/src/modules/core/routes/Validators/Validators.tsx
+++ b/web-app/src/modules/core/routes/Validators/Validators.tsx
@@ -18,14 +18,14 @@ const GET_VALIDATORS = gql`
         failedBlocks
         proposedBlocks
       }
-      grade {
-        compliant
-        failedBlocks
-        proposedBlocks
-      }
       vouches {
-        address
-        epoch
+        compliant
+        valid
+        total
+        vouchers {
+          address
+          epoch
+        }
       }
       currentBid {
         currentBid

--- a/web-app/src/modules/core/routes/Validators/components/ValidatorsTable.tsx
+++ b/web-app/src/modules/core/routes/Validators/components/ValidatorsTable.tsx
@@ -94,8 +94,8 @@ const ValidatorsTable: FC<ValidatorsTableProps> = ({ validators }) => {
         value2 = b.auditQualification ? b.auditQualification[b.auditQualification.length - 1] : '';
         break;
       case 'vouches':
-        value1 = a.vouches.length;
-        value2 = b.vouches.length;
+        value1 = a.vouches.valid;
+        value2 = b.vouches.valid;
         break;
       case 'currentBid':
         value1 = a.currentBid ? a.currentBid.currentBid : 0;

--- a/web-app/src/modules/core/routes/Validators/components/ValidatorsTable.tsx
+++ b/web-app/src/modules/core/routes/Validators/components/ValidatorsTable.tsx
@@ -205,9 +205,35 @@ const ValidatorsTable: FC<ValidatorsTableProps> = ({ validators }) => {
                     ))}
               </tbody>
             </table>
+            {activeValue === 'inactive' && <AuditLegend />}
           </div>
         </div>
       </div>
+    </div>
+  );
+};
+
+const AuditLegend: FC = () => {
+  const legendItems = [
+    { code: 11, description: 'Validator is not configured' },
+    { code: 12, description: 'Not a slow wallet' },
+    { code: 13, description: 'Validator is jailed' },
+    { code: 14, description: 'No enough vouches' },
+    { code: 15, description: 'Bid is zero' },
+    { code: 16, description: 'Bid has expired' },
+    { code: 17, description: 'Not enough coin balance' },
+  ];
+
+  return (
+    <div className="mt-4 p-4 bg-[#F5F5F5] text-[#525252] rounded-md">
+      <h2 className="text-lg font-bold mb-2">Audit Legend</h2>
+      <ul className="list-disc pl-5 space-y-1">
+        {legendItems.map((item) => (
+          <li key={item.code}>
+            <strong>{item.code}:</strong> {item.description}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 };

--- a/web-app/src/modules/core/routes/Validators/components/Vouches.tsx
+++ b/web-app/src/modules/core/routes/Validators/components/Vouches.tsx
@@ -1,26 +1,43 @@
 import { FC, useState } from 'react';
 import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from '@headlessui/react';
-import { XMarkIcon } from '@heroicons/react/24/outline';
+import { CheckIcon, XMarkIcon } from '@heroicons/react/24/outline';
 
 import AccountAddress from '../../../../ui/AccountAddress';
 
-interface Vouch {
-  address: string;
-  epoch: number;
+interface Vouches {
+  compliant: boolean;
+  valid: number;
+  total: number;
+  vouchers: {
+    address: string;
+    epoch: number;
+  }[];
 }
 
 interface VouchesProps {
-  vouches: Vouch[];
+  vouches: Vouches;
 }
 
 const Vouches: FC<VouchesProps> = ({ vouches }) => {
   const [open, setOpen] = useState(!true);
 
+  const sortedVouchers = vouches.vouchers.slice().sort((a, b) => {
+    if (a.epoch === b.epoch) {
+      return a.address.localeCompare(b.address);
+    }
+    return b.epoch - a.epoch;
+  });
+
   return (
     <>
       <div>
         <button type="button" onClick={() => setOpen(true)}>
-          {vouches.length.toLocaleString()}
+          {vouches.compliant ? (
+            <CheckIcon className="w-5 h-5 text-green-500 inline" style={{ marginTop: '-3px' }} />
+          ) : (
+            <XMarkIcon className="w-5 h-5 text-red-500 inline" style={{ marginTop: '-3px' }} />
+          )}
+          {vouches.valid} / {vouches.total}
         </button>
       </div>
 
@@ -77,7 +94,7 @@ const Vouches: FC<VouchesProps> = ({ vouches }) => {
                             </tr>
                           </thead>
                           <tbody className="divide-y divide-gray-200 bg-white">
-                            {vouches.map((vouch, index) => (
+                            {sortedVouchers.map((vouch, index) => (
                               <tr key={index} className="text-sm text-[#141414] text-center">
                                 <td className="px-2 py-2">{index + 1}</td>
                                 <td className="px-2 py-2">{vouch.epoch}</td>

--- a/web-app/src/modules/interface/Validator.interface.ts
+++ b/web-app/src/modules/interface/Validator.interface.ts
@@ -1,3 +1,13 @@
+interface Vouches {
+  valid: number;
+  total: number;
+  compliant: boolean;
+  vouchers: {
+    address: string;
+    epoch: number;
+  }[];
+}
+
 export interface IValidator {
   address: string;
   inSet: boolean;
@@ -5,10 +15,7 @@ export interface IValidator {
   votingPower: number;
   balance?: number;
   unlocked?: number;
-  vouches: {
-    epoch: number;
-    address: string;
-  }[];
+  vouches: Vouches;
   grade: {
     compliant: boolean;
     failedBlocks: number;


### PR DESCRIPTION
To provide clarity for validator operators, I am adding error code descriptions to the 'audit' column in the inactive validators table. This allows validators to clearly see the reasons they are not being included in the validator set:


![image](https://github.com/user-attachments/assets/e9e99928-7252-44df-b41b-d4c22ec904d0)


Also this PR changes the voucher display to show compliance status and the valid/total ratio:


![image](https://github.com/user-attachments/assets/f6ee0cdd-2ccd-46cf-841f-dfd38546d2e0)
